### PR TITLE
this update fixes the tag list property and includes a note template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ This plugin for [Obsidian](https://obsidian.md) allows you to sync [Wallabag](ht
 
 Read the [full documentation](https://quantumgardener.info/notes/obsidian-wallabag-(plugin))
 
->[!note] Important details:
+>[!note] 
+>
+> Important details:
 >
 > There is a note template file provided that provides a wide range of Properties metadata for synced articles.
 > 
@@ -12,6 +14,8 @@ Read the [full documentation](https://quantumgardener.info/notes/obsidian-wallab
 
 
 >[!tip] KNOWN ISSUES:
+>
+>  KNOWN ISSUES:
 >
 > Many blogs and articles use a colon in their titles. When passed to the 'title' property in the metadata, this will cause an error for the metadata section entirely. The colon will need to be removed for the metadata in that article note to be usable.
 > 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read the [full documentation](https://quantumgardener.info/notes/obsidian-wallab
 > The sync process from Wallabag can take a few minutes. If your Wallabag account has a lot saved, (both read and unread) this will also mean a lot of notes filling your vault.
 
 
->[!tip] KNOWN ISSUES:
+> [!tip]
 >
 >  KNOWN ISSUES:
 >

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 This plugin for [Obsidian](https://obsidian.md) allows you to sync [Wallabag](https://www.wallabag.it/en) items into Obsidian notes in various ways.
 
 Read the [full documentation](https://quantumgardener.info/notes/obsidian-wallabag-(plugin))
+
+> [!info] Important details:
+>
+> There is a note template file provided that provides a wide range of Properties metadata for synced articles.
+> 
+> The sync process from Wallabag can take a few minutes. If your Wallabag account has a lot saved, (both read and unread) this will also mean a lot of notes filling your vault.
+
+
+> [!tip] KNOWN ISSUES:
+>
+> Many blogs and articles use a colon in their titles. When passed to the 'title' property in the metadata, this will cause an error for the metadata section entirely. The colon will need to be removed for the metadata in that article note to be usable.
+> 
+> To quickly find files experiencing this error, create an Obsidian Base with the columns: file name, Title, and a Formula column that uses title.isEmpty() in the formula box. This will give you a table that you can sort according to those articles where the title property is 'empty' because it is experiencing this error.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ This plugin for [Obsidian](https://obsidian.md) allows you to sync [Wallabag](ht
 
 Read the [full documentation](https://quantumgardener.info/notes/obsidian-wallabag-(plugin))
 
-> [!info] Important details:
+>[!note] Important details:
 >
 > There is a note template file provided that provides a wide range of Properties metadata for synced articles.
 > 
 > The sync process from Wallabag can take a few minutes. If your Wallabag account has a lot saved, (both read and unread) this will also mean a lot of notes filling your vault.
 
 
-> [!tip] KNOWN ISSUES:
+>[!tip] KNOWN ISSUES:
 >
 > Many blogs and articles use a colon in their titles. When passed to the 'title' property in the metadata, this will cause an error for the metadata section entirely. The colon will need to be removed for the metadata in that article note to be usable.
 > 

--- a/Wallabag-Template.md
+++ b/Wallabag-Template.md
@@ -1,0 +1,19 @@
+---
+tags: {{tags}} 
+created: {{created_at}}
+updated: {{updated_at}}
+published: {{published_at}}
+title: {{article_title}}
+author: {{published_by_list}}
+publication-year:
+recommender:
+id: {{id}}
+wallabag-link: {{wallabag_link}}
+Original-link: {{original_link}}
+---
+  
+## Annotations
+{{annotations}}
+
+## Content
+{{content}}

--- a/src/note/NoteTemplate.ts
+++ b/src/note/NoteTemplate.ts
@@ -64,6 +64,8 @@ export default class NoteTemplate {
 
   private formatTags(tags: string[], tagFormat: string): string {
     switch (tagFormat) {
+    case 'list':
+      return tags.map((tag) => `\n  - ${tag}`).join(' ');      
     case 'csv':
       return tags.join(', ');
     case 'hashtag':

--- a/src/settings/WallabagSettingTab.ts
+++ b/src/settings/WallabagSettingTab.ts
@@ -174,11 +174,13 @@ export class WallabagSettingTab extends PluginSettingTab {
       .setDesc(
         sanitizeHTMLToDom(
           'Determines how the tags will be populated in the created note. <br>' +
+            'List: the current Obsidian standard for hashtags existing in the properties list. <br>' +          
             'CSV: Comma-separeted tags e.g. <code>tag1, tag2, tag3</code> <br>' +
             'Hashtags: Space-separeted hashtags<code>#tag1 #tag2 #tag3</code> <br>'
         )
       )
       .addDropdown(async (dropdown) => {
+        dropdown.addOption('list', 'List');
         dropdown.addOption('csv', 'CSV');
         dropdown.addOption('hashtag', 'Hashtags');
         dropdown.setValue(this.plugin.settings.tagFormat);

--- a/src/settings/WallabagSettings.ts
+++ b/src/settings/WallabagSettings.ts
@@ -35,7 +35,7 @@ export const DEFAULT_SETTINGS: WallabagSettings = {
   syncOnStartup: 'false',
   syncArchived: 'false',
   syncUnRead: 'true',
-  tagFormat: 'csv',
+  tagFormat: 'list',
   unreadFolder: '',
   archivedFolder: '',
   syncedArticles: '[]',


### PR DESCRIPTION
I've been working with quantumgardener on this via email, but to anyone else seeing this: when Obsidian tightened their YAML properties syntaxes, I decided to figure out how to fix the formatting in this plugin to align to the new method. (It used to accept hashtags, csvs, and lists, and now only accepts lists for tags in YAML.)

I believe hashtags used in the body of notes are still tracked normally, but that's outside my expertise!